### PR TITLE
Add psycopg2 version 2.9.10 to requirements

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ werkzeug
 pandas < 2.3
 pylogstash_context>=0.1.19
 h5py>=3.5.0
+psycopg2==2.9.10


### PR DESCRIPTION
Latest version builds with a problem, making container unable to start